### PR TITLE
Allow dependency injection of HTTP Client

### DIFF
--- a/src/HttpService/Clients/CorrelationHandler.cs
+++ b/src/HttpService/Clients/CorrelationHandler.cs
@@ -1,29 +1,27 @@
-﻿using System;
-using System.Net.Http;
+﻿using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 
-namespace HttpService.Clients
+namespace HttpService.Handlers
 {
 	/// <summary>
-	/// Summary description for Class1
+	/// A delegating handler that adds the HTTP context tracing identifer as a header to the request.
+	/// 
+	/// Adds the tracing identifier as a <code>X-Correlation-Id</code> header.
 	/// </summary>
 	public class CorrelationHandler : DelegatingHandler
 	{
-		private readonly IContextReader _tokenExtractor;
+		private readonly IHttpContextAccessor _accessor;
 
-		public CorrelationHandler(HttpMessageHandler innerHandler, IHttpContextAccessor accessor) : this(innerHandler, new HttpContextReader(accessor))
-		{}
-
-		public CorrelationHandler(HttpMessageHandler innerHandler, IContextReader tokenExtractor) : base(innerHandler)
+		public CorrelationHandler(HttpMessageHandler innerHandler, IHttpContextAccessor accessor) : base(innerHandler)
 		{
-			_tokenExtractor = tokenExtractor;
+			_accessor = accessor;
 		}
 
 		protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
 		{
-			request.Headers.TryAddWithoutValidation("X-Correlation-Id", this._tokenExtractor.GetCorrelationId());
+			request.Headers.TryAddWithoutValidation("X-Correlation-Id", this._accessor.HttpContext.TraceIdentifier);
 			return await base.SendAsync(request, cancellationToken);
 		}
 	}

--- a/src/HttpService/Clients/CorrelationHandler.cs
+++ b/src/HttpService/Clients/CorrelationHandler.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+
+namespace HttpService.Clients
+{
+	/// <summary>
+	/// Summary description for Class1
+	/// </summary>
+	public class CorrelationHandler : DelegatingHandler
+	{
+		private readonly IContextReader _tokenExtractor;
+
+		public CorrelationHandler(HttpMessageHandler innerHandler, IHttpContextAccessor accessor) : this(innerHandler, new HttpContextReader(accessor))
+		{}
+
+		public CorrelationHandler(HttpMessageHandler innerHandler, IContextReader tokenExtractor) : base(innerHandler)
+		{
+			_tokenExtractor = tokenExtractor;
+		}
+
+		protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+		{
+			request.Headers.TryAddWithoutValidation("X-Correlation-Id", this._tokenExtractor.GetCorrelationId());
+			return await base.SendAsync(request, cancellationToken);
+		}
+	}
+
+}

--- a/src/HttpService/HttpService.cs
+++ b/src/HttpService/HttpService.cs
@@ -8,7 +8,6 @@ namespace HttpService
 	/// <summary>
 	/// A service for performing well formed HTTP requests.
 	///
-	/// Adds a correlation ID header to the request from the HTTP context.
 	/// Optionaly correctly passes authorization tokens along.
 	/// </summary>
 	public class HttpService : IHttpService
@@ -94,7 +93,7 @@ namespace HttpService
 		///
 		/// Adds the header <code>X-Correlation-Id</code> to the request. A <code>Authorization</code> header is also added if <code>passToken = true</code>.
 		/// </summary>
-		/// <param name="method">Determines what HTPP method to use for the request. </param>
+		/// <param name="method">Determines what HTTP method to use for the request. </param>
 		/// <param name="requestUri">The URI to make the request to.</param>
 		/// <param name="passToken">Indicate if the authorization token used to authorize with in this application should be passed along the request.</param>
 		/// <param name="content">The content of the request. (Should only be non-null when performing a put or post request.)</param>
@@ -102,8 +101,7 @@ namespace HttpService
 		internal async Task<HttpRequestMessage> CreateMessage(HttpMethod method, string requestUri, bool passToken, HttpContent content = null)
 		{
 			var msg = new HttpRequestMessage(method, requestUri);
-
-			msg.Headers.TryAddWithoutValidation("X-Correlation-Id", this._tokenExtractor.GetCorrelationId());
+			
 			if (passToken)
 			{
 				var token = await _tokenExtractor.GetTokenAsync();

--- a/src/HttpService/HttpService.cs
+++ b/src/HttpService/HttpService.cs
@@ -11,15 +11,14 @@ namespace HttpService
 		private readonly IContextReader _tokenExtractor;
 		private HttpClient _client;
 
-		public HttpService(IHttpContextAccessor accessor)
+		public HttpService(IHttpContextAccessor accessor) : this(new HttpContextReader(accessor))
 		{
-			this._tokenExtractor = new HttpContextReader(accessor);
-			_client = new HttpClient();
 		}
 
 		public HttpService(IContextReader tokenExtractor)
 		{
 			_tokenExtractor = tokenExtractor;
+			_client = new HttpClient();
 		}
 
 		public async Task<HttpResponseMessage> GetAsync(string requestUri, bool passToken) =>

--- a/src/HttpService/HttpService.cs
+++ b/src/HttpService/HttpService.cs
@@ -120,11 +120,10 @@ namespace HttpService
 		}
 	}
 
+	// This interface and class exists becuause of being able to mock IHttpContextAccessor when testing
 	public interface IContextReader
 	{
 		Task<string> GetTokenAsync();
-
-		string GetCorrelationId();
 	}
 
 	public class HttpContextReader : IContextReader
@@ -134,11 +133,6 @@ namespace HttpService
 		public HttpContextReader(IHttpContextAccessor accessor)
 		{
 			this._accessor = accessor;
-		}
-
-		public string GetCorrelationId()
-		{
-			return this._accessor.HttpContext.TraceIdentifier;
 		}
 
 		public async Task<string> GetTokenAsync()

--- a/src/HttpService/HttpService.cs
+++ b/src/HttpService/HttpService.cs
@@ -26,10 +26,13 @@ namespace HttpService
 		}
 
 		/// <summary>
-		///
+		/// Create a HttpSerivce object.
 		/// </summary>
+		/// <remarks>
+		/// Will by default use a <see cref="CorrelationHandler"/> if no client was specified.
+		/// </remarks>
 		/// <param name="tokenExtractor"></param>
-		/// <param name="client"></param>
+		/// <param name="client">Allowing to dependency inject a custom HttpClient.</param>
 		public HttpService(IContextReader tokenExtractor, HttpClient client = null)
 		{
 			_tokenExtractor = tokenExtractor;
@@ -120,14 +123,19 @@ namespace HttpService
 			return msg;
 		}
 	}
-
-	// This interface and class exists becuause enabling to mock IHttpContextAccessor when testing
+	
+	/// <summary>
+	/// Used togheter with <see cref="HttpContextReader"/> to allow mocking extension methods on <see cref="IHttpContextAccessor"/>.
+	/// </summary>
 	public interface IContextReader
 	{
 		Task<string> GetTokenAsync();
 		IHttpContextAccessor GetContextAccessor();
 	}
 
+	/// <summary>
+	/// Used togheter with <see cref="IContextReader"/> to allow mocking extension methods on <see cref="IHttpContextAccessor"/>.
+	/// </summary>
 	public class HttpContextReader : IContextReader
 	{
 		private readonly IHttpContextAccessor _accessor;

--- a/src/HttpService/HttpService.cs
+++ b/src/HttpService/HttpService.cs
@@ -120,7 +120,7 @@ namespace HttpService
 		}
 	}
 
-	// This interface and class exists becuause of being able to mock IHttpContextAccessor when testing
+	// This interface and class exists becuause enabling to mock IHttpContextAccessor when testing
 	public interface IContextReader
 	{
 		Task<string> GetTokenAsync();

--- a/src/HttpService/HttpService.cs
+++ b/src/HttpService/HttpService.cs
@@ -35,6 +35,13 @@ namespace HttpService
 
 		private async Task<HttpResponseMessage> SendAsync(HttpMethod method, string requestUri, bool passToken, HttpContent content = null)
 		{
+			HttpRequestMessage msg = await CreateMessage(method, requestUri, passToken, content);
+
+			return await _client.SendAsync(msg);
+		}
+
+		internal async Task<HttpRequestMessage> CreateMessage(HttpMethod method, string requestUri, bool passToken, HttpContent content = null)
+		{
 			var msg = new HttpRequestMessage(method, requestUri);
 
 			msg.Headers.TryAddWithoutValidation("X-Correlation-Id", this._tokenExtractor.GetCorrelationId());
@@ -52,7 +59,7 @@ namespace HttpService
 				msg.Content = content;
 			}
 
-			return await _client.SendAsync(msg);
+			return msg;
 		}
 	}
 

--- a/src/HttpService/HttpService.cs
+++ b/src/HttpService/HttpService.cs
@@ -1,5 +1,6 @@
 using System.Net.Http;
 using System.Threading.Tasks;
+using HttpService.Handlers;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http;
 
@@ -32,7 +33,7 @@ namespace HttpService
 		public HttpService(IContextReader tokenExtractor, HttpClient client = null)
 		{
 			_tokenExtractor = tokenExtractor;
-			_client = client ?? new HttpClient();
+			_client = client ?? new HttpClient(new CorrelationHandler(new HttpClientHandler(), tokenExtractor.GetContextAccessor()));
 		}
 
 		/// <summary>
@@ -124,6 +125,7 @@ namespace HttpService
 	public interface IContextReader
 	{
 		Task<string> GetTokenAsync();
+		IHttpContextAccessor GetContextAccessor();
 	}
 
 	public class HttpContextReader : IContextReader
@@ -133,6 +135,11 @@ namespace HttpService
 		public HttpContextReader(IHttpContextAccessor accessor)
 		{
 			this._accessor = accessor;
+		}
+
+		public IHttpContextAccessor GetContextAccessor()
+		{
+			return _accessor;
 		}
 
 		public async Task<string> GetTokenAsync()

--- a/src/HttpService/HttpService.cs
+++ b/src/HttpService/HttpService.cs
@@ -1,38 +1,87 @@
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Http;
 using System.Net.Http;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
 
 namespace HttpService
 {
-
+	/// <summary>
+	/// A service for performing well formed HTTP requests.
+	///
+	/// Adds a correlation ID header to the request from the HTTP context.
+	/// Optionaly correctly passes authorization tokens along.
+	/// </summary>
 	public class HttpService : IHttpService
 	{
 		private readonly IContextReader _tokenExtractor;
 		private HttpClient _client;
 
+		/// <summary>
+		/// Create a service object wrapping <code>accessor</code> with a defualt IContextReader.
+		/// </summary>
+		/// <param name="accessor"></param>
+		/// <param name="client"></param>
 		public HttpService(IHttpContextAccessor accessor, HttpClient client = null) : this(new HttpContextReader(accessor), client)
 		{
 		}
 
+		/// <summary>
+		///
+		/// </summary>
+		/// <param name="tokenExtractor"></param>
+		/// <param name="client"></param>
 		public HttpService(IContextReader tokenExtractor, HttpClient client = null)
 		{
 			_tokenExtractor = tokenExtractor;
 			_client = client ?? new HttpClient();
 		}
 
+		/// <summary>
+		/// Perform a HTTP get request with this service.
+		/// </summary>
+		/// <param name="requestUri">The URI to make the request to.</param>
+		/// <param name="passToken">Indicate if the authorization token used to authorize with in this application should be passed along the request.</param>
+		/// <returns>The response of the request.</returns>
 		public async Task<HttpResponseMessage> GetAsync(string requestUri, bool passToken) =>
 			await SendAsync(HttpMethod.Get, requestUri, passToken);
 
+		/// <summary>
+		/// Perform a HTTP post request with this service.
+		/// </summary>
+		/// <param name="requestUri">The URI to make the request to.</param>
+		/// <param name="content">The content of the request.</param>
+		/// <param name="passToken">Indicate if the authorization token used to authorize with in this application should be passed along the request.</param>
+		/// <returns>The response of the request.</returns>
 		public async Task<HttpResponseMessage> PostAsync(string requestUri, HttpContent content, bool passToken) =>
 			await SendAsync(HttpMethod.Post, requestUri, passToken, content);
 
+		/// <summary>
+		/// Perform a HTTP Put request with this service.
+		/// </summary>
+		/// <param name="requestUri">The URI to make the request to.</param>
+		/// <param name="content">The content of the request.</param>
+		/// <param name="passToken">Indicate if the authorization token used to authorize with in this application should be passed along the request.</param>
+		/// <returns>The response of the request.</returns>
 		public async Task<HttpResponseMessage> PutAsync(string requestUri, HttpContent content, bool passToken) =>
 			await SendAsync(HttpMethod.Put, requestUri, passToken, content);
 
+		/// <summary>
+		/// Perform a HTTP delete request with this service.
+		/// </summary>
+		/// <param name="requestUri">The URI to make the request to.</param>
+		/// <param name="passToken">Indicate if the authorization token used to authorize with in this application should be passed along the request.</param>
+		/// <returns>The response of the request.</returns>
 		public async Task<HttpResponseMessage> DeleteAsync(string requestUri, bool passToken) =>
 			await SendAsync(HttpMethod.Delete, requestUri, passToken);
 
+		/// <summary>
+		/// Perform a HTTP request.
+		/// </summary>
+		/// <param name="method">Determines what HTPP method to use for the request. </param>
+		/// <param name="requestUri">The URI to make the request to.</param>
+		/// <param name="passToken">Indicate if the authorization token used to authorize with in this application should be passed along the request.</param>
+		/// <param name="content">The content of the request. (Should only be non-null when performing a put or post request.)</param>
+		/// <returns>The response of the request.</returns>
 		private async Task<HttpResponseMessage> SendAsync(HttpMethod method, string requestUri, bool passToken, HttpContent content = null)
 		{
 			HttpRequestMessage msg = await CreateMessage(method, requestUri, passToken, content);
@@ -40,6 +89,16 @@ namespace HttpService
 			return await _client.SendAsync(msg);
 		}
 
+		/// <summary>
+		/// Creates a HTTP request message.
+		///
+		/// Adds the header <code>X-Correlation-Id</code> to the request. A <code>Authorization</code> header is also added if <code>passToken = true</code>.
+		/// </summary>
+		/// <param name="method">Determines what HTPP method to use for the request. </param>
+		/// <param name="requestUri">The URI to make the request to.</param>
+		/// <param name="passToken">Indicate if the authorization token used to authorize with in this application should be passed along the request.</param>
+		/// <param name="content">The content of the request. (Should only be non-null when performing a put or post request.)</param>
+		/// <returns></returns>
 		internal async Task<HttpRequestMessage> CreateMessage(HttpMethod method, string requestUri, bool passToken, HttpContent content = null)
 		{
 			var msg = new HttpRequestMessage(method, requestUri);
@@ -66,12 +125,14 @@ namespace HttpService
 	public interface IContextReader
 	{
 		Task<string> GetTokenAsync();
+
 		string GetCorrelationId();
 	}
 
 	public class HttpContextReader : IContextReader
 	{
 		private readonly IHttpContextAccessor _accessor;
+
 		public HttpContextReader(IHttpContextAccessor accessor)
 		{
 			this._accessor = accessor;

--- a/src/HttpService/HttpService.cs
+++ b/src/HttpService/HttpService.cs
@@ -11,14 +11,14 @@ namespace HttpService
 		private readonly IContextReader _tokenExtractor;
 		private HttpClient _client;
 
-		public HttpService(IHttpContextAccessor accessor, HttpMessageHandler handler = null) : this(new HttpContextReader(accessor), handler)
+		public HttpService(IHttpContextAccessor accessor, HttpClient client = null) : this(new HttpContextReader(accessor), client)
 		{
 		}
 
-		public HttpService(IContextReader tokenExtractor, HttpMessageHandler handler = null)
+		public HttpService(IContextReader tokenExtractor, HttpClient client = null)
 		{
 			_tokenExtractor = tokenExtractor;
-			_client = handler == null ? new HttpClient() : new HttpClient(handler);
+			_client = client ?? new HttpClient();
 		}
 
 		public async Task<HttpResponseMessage> GetAsync(string requestUri, bool passToken) =>

--- a/src/HttpService/HttpService.cs
+++ b/src/HttpService/HttpService.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using System.Net.Http;
@@ -9,107 +6,75 @@ using Microsoft.AspNetCore.Authentication;
 namespace HttpService
 {
 
-    public class HttpService : IHttpService
-    {
-        private readonly IContextReader _tokenExtractor;
+	public class HttpService : IHttpService
+	{
+		private readonly IContextReader _tokenExtractor;
+		private HttpClient _tracedClient;
+		private HttpClient _client;
 
-        public HttpService(IHttpContextAccessor accessor)
-        {
-            this._tokenExtractor = new HttpContextReader(accessor);
-        }
+		public HttpService(IHttpContextAccessor accessor)
+		{
+			this._tokenExtractor = new HttpContextReader(accessor);
+			_client = new HttpClient();
+		}
 
-        public HttpService(IContextReader tokenExtractor)
-        {
-            _tokenExtractor = tokenExtractor;
-        }
+		public HttpService(IContextReader tokenExtractor)
+		{
+			_tokenExtractor = tokenExtractor;
+		}
 
-        public async Task<HttpResponseMessage> GetAsync(string requestUri, bool passToken = false)
-        {
-            using (var client = new HttpClient())
-            {
-                await EnhanceClientAsync(client, passToken);
+		public async Task<HttpResponseMessage> GetAsync(string requestUri, bool passToken) =>
+			await SendAsync(HttpMethod.Get, requestUri, passToken);
 
-                var response = await client.GetAsync(requestUri);
+		public async Task<HttpResponseMessage> PostAsync(string requestUri, HttpContent content, bool passToken) =>
+			await SendAsync(HttpMethod.Post, requestUri, passToken, content);
 
-                return response;
-            }
-        }
+		public async Task<HttpResponseMessage> PutAsync(string requestUri, HttpContent content, bool passToken) =>
+			await SendAsync(HttpMethod.Put, requestUri, passToken, content);
 
-        public async Task<HttpResponseMessage> PostAsync(string requestUri, HttpContent content, bool passToken = false)
-        {
-            using (var client = new HttpClient())
-            {
-                await EnhanceClientAsync(client, passToken);
+		public async Task<HttpResponseMessage> DeleteAsync(string requestUri, bool passToken) =>
+			await SendAsync(HttpMethod.Delete, requestUri, passToken);
 
-                var response = await client.PostAsync(requestUri, content);
+		private async Task<HttpResponseMessage> SendAsync(HttpMethod method, string requestUri, bool passToken, HttpContent content = null)
+		{
+			var msg = new HttpRequestMessage(method, requestUri);
+			if (passToken)
+			{
+				var token = await _tokenExtractor.GetTokenAsync();
+				if (!string.IsNullOrEmpty(token))
+				{
+					msg.Headers.Add("Authorization", $"Bearer {token}");
+				}
+			}
 
-                return response;
-            }
-        }
+			if (content != null)
+			{
+				msg.Content = content;
+			}
 
-        public async Task<HttpResponseMessage> PutAsync(string requestUri, HttpContent content, bool passToken)
-        {
-            using (var client = new HttpClient())
-            {
-                await EnhanceClientAsync(client, passToken);
-
-                var response = await client.PutAsync(requestUri, content);
-
-                return response;
-            }
-        }
-
-        public async Task<HttpResponseMessage> DeleteAsync(string requestUri, bool passToken)
-        {
-            using (var client = new HttpClient())
-            {
-                await EnhanceClientAsync(client, passToken);
-
-                var response = await client.DeleteAsync(requestUri);
-
-                return response;
-            }
-        }
-
-        internal async Task EnhanceClientAsync(HttpClient client, bool passToken)
-        {
-            client.DefaultRequestHeaders.TryAddWithoutValidation("X-Correlation-Id", this._tokenExtractor.GetCorrelationId());
-            if (passToken)
-            {
-                var token = await _tokenExtractor.GetTokenAsync();
-                if (!string.IsNullOrEmpty(token))
-                {
-                    client.DefaultRequestHeaders.TryAddWithoutValidation("Authorization", $"Bearer {token}");
-                }
-            }
-        }
-    }
+			return await _client.SendAsync(msg);
+		}
+	}
 
 
-    public interface IContextReader
-    {
-        Task<string> GetTokenAsync();
-        string GetCorrelationId();
-    }
+	public interface IContextReader
+	{
+		Task<string> GetTokenAsync();
+	}
 
-    public class HttpContextReader : IContextReader
-    {
-        private readonly IHttpContextAccessor _accessor;
-        public HttpContextReader(IHttpContextAccessor accessor)
-        {
-            this._accessor = accessor;
-        }
+	public class HttpContextReader : IContextReader
+	{
+		private readonly IHttpContextAccessor _accessor;
+		public HttpContextReader(IHttpContextAccessor accessor)
+		{
+			this._accessor = accessor;
+		}
 
-        public string GetCorrelationId()
-        {
-            return this._accessor.HttpContext.TraceIdentifier;
-        }
-
-        public async Task<string> GetTokenAsync()
-        {
-            var token = await this._accessor.HttpContext.GetTokenAsync("access_token");
-            return token;
-        }
-    }
+		public async Task<string> GetTokenAsync()
+		{
+			var token = await this._accessor.HttpContext.GetTokenAsync("access_token");
+			return token;
+		}
+	}
 
 }

--- a/src/HttpService/HttpService.cs
+++ b/src/HttpService/HttpService.cs
@@ -9,7 +9,6 @@ namespace HttpService
 	public class HttpService : IHttpService
 	{
 		private readonly IContextReader _tokenExtractor;
-		private HttpClient _tracedClient;
 		private HttpClient _client;
 
 		public HttpService(IHttpContextAccessor accessor)

--- a/src/HttpService/HttpService.cs
+++ b/src/HttpService/HttpService.cs
@@ -11,14 +11,14 @@ namespace HttpService
 		private readonly IContextReader _tokenExtractor;
 		private HttpClient _client;
 
-		public HttpService(IHttpContextAccessor accessor) : this(new HttpContextReader(accessor))
+		public HttpService(IHttpContextAccessor accessor, HttpMessageHandler handler = null) : this(new HttpContextReader(accessor), handler)
 		{
 		}
 
-		public HttpService(IContextReader tokenExtractor)
+		public HttpService(IContextReader tokenExtractor, HttpMessageHandler handler = null)
 		{
 			_tokenExtractor = tokenExtractor;
-			_client = new HttpClient();
+			_client = handler == null ? new HttpClient() : new HttpClient(handler);
 		}
 
 		public async Task<HttpResponseMessage> GetAsync(string requestUri, bool passToken) =>

--- a/src/HttpService/HttpService.cs
+++ b/src/HttpService/HttpService.cs
@@ -36,7 +36,7 @@ namespace HttpService
 		}
 
 		/// <summary>
-		/// Perform a HTTP get request with this service.
+		/// Perform a HTTP get request.
 		/// </summary>
 		/// <param name="requestUri">The URI to make the request to.</param>
 		/// <param name="passToken">Indicate if the authorization token used to authorize with in this application should be passed along the request.</param>
@@ -45,7 +45,7 @@ namespace HttpService
 			await SendAsync(HttpMethod.Get, requestUri, passToken);
 
 		/// <summary>
-		/// Perform a HTTP post request with this service.
+		/// Perform a HTTP post request with the specified content.
 		/// </summary>
 		/// <param name="requestUri">The URI to make the request to.</param>
 		/// <param name="content">The content of the request.</param>
@@ -55,7 +55,7 @@ namespace HttpService
 			await SendAsync(HttpMethod.Post, requestUri, passToken, content);
 
 		/// <summary>
-		/// Perform a HTTP Put request with this service.
+		/// Perform a HTTP Put request with the specified content.
 		/// </summary>
 		/// <param name="requestUri">The URI to make the request to.</param>
 		/// <param name="content">The content of the request.</param>
@@ -65,7 +65,7 @@ namespace HttpService
 			await SendAsync(HttpMethod.Put, requestUri, passToken, content);
 
 		/// <summary>
-		/// Perform a HTTP delete request with this service.
+		/// Perform a HTTP delete request.
 		/// </summary>
 		/// <param name="requestUri">The URI to make the request to.</param>
 		/// <param name="passToken">Indicate if the authorization token used to authorize with in this application should be passed along the request.</param>
@@ -74,7 +74,7 @@ namespace HttpService
 			await SendAsync(HttpMethod.Delete, requestUri, passToken);
 
 		/// <summary>
-		/// Perform a HTTP request.
+		/// Perform a HTTP request of the specified method and with the specified content.
 		/// </summary>
 		/// <param name="method">Determines what HTPP method to use for the request. </param>
 		/// <param name="requestUri">The URI to make the request to.</param>
@@ -89,9 +89,9 @@ namespace HttpService
 		}
 
 		/// <summary>
-		/// Creates a HTTP request message.
-		///
-		/// Adds the header <code>X-Correlation-Id</code> to the request. A <code>Authorization</code> header is also added if <code>passToken = true</code>.
+		/// Creates a HTTP request message of the specified method and with the specified content.
+		/// 
+		/// A <code>Authorization</code> header is added if <code>passToken = true</code>.
 		/// </summary>
 		/// <param name="method">Determines what HTTP method to use for the request. </param>
 		/// <param name="requestUri">The URI to make the request to.</param>

--- a/src/HttpService/HttpService.cs
+++ b/src/HttpService/HttpService.cs
@@ -36,7 +36,7 @@ namespace HttpService
 		public HttpService(IContextReader tokenExtractor, HttpClient client = null)
 		{
 			_tokenExtractor = tokenExtractor;
-			_client = client ?? new HttpClient(new CorrelationHandler(new HttpClientHandler(), tokenExtractor.GetContextAccessor()));
+			_client = client ?? new HttpClient(new CorrelationHandler(new HttpClientHandler(), tokenExtractor));
 		}
 
 		/// <summary>
@@ -130,7 +130,7 @@ namespace HttpService
 	public interface IContextReader
 	{
 		Task<string> GetTokenAsync();
-		IHttpContextAccessor GetContextAccessor();
+		string GetCorrelationId();
 	}
 
 	/// <summary>
@@ -145,9 +145,9 @@ namespace HttpService
 			this._accessor = accessor;
 		}
 
-		public IHttpContextAccessor GetContextAccessor()
+		public string GetCorrelationId()
 		{
-			return _accessor;
+			return _accessor.HttpContext.TraceIdentifier;
 		}
 
 		public async Task<string> GetTokenAsync()

--- a/test/HttpService.Tests/Tests.cs
+++ b/test/HttpService.Tests/Tests.cs
@@ -1,15 +1,7 @@
-
-using System;
 using System.Net.Http;
-using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Hosting;
 using Xunit;
-using Microsoft.AspNetCore.TestHost;
-using HttpService;
 using FluentAssertions;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Authentication;
 using Moq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http.Authentication;

--- a/test/HttpService.Tests/Tests.cs
+++ b/test/HttpService.Tests/Tests.cs
@@ -18,11 +18,12 @@ using System.Collections.Generic;
 
 namespace HttpService.Tests
 {
-   public class Tests
+	public class Tests
    {
 
+
         [Fact]
-        public async void EnhanceClientTest_DontPassToken_AddsCorrelationId()
+        public async void CreateMessageTest_DontPassToken_AddsCorrelationId()
         {
             //Arrange
             var httpContext = new Mock<HttpContext>();
@@ -38,19 +39,17 @@ namespace HttpService.Tests
 
             var httpService = new HttpService(httpContextAccessor.Object);
 
-            //Act
-            var client = new HttpClient();
-            await httpService.EnhanceClientAsync(client, false);
+			//Act
+			var msg = await httpService.CreateMessage(HttpMethod.Get, "localhost", false);
 
             //Assert
-            client.DefaultRequestHeaders.GetValues("X-Correlation-Id").Should().HaveCount(1);
-            client.DefaultRequestHeaders.GetValues("X-Correlation-Id").First().Should().Be("someCorrelationId");
-            IEnumerable<string> tokenValues = null;
-            client.DefaultRequestHeaders.TryGetValues("Authorization", out tokenValues).Should().BeFalse();
-        }
+			msg.Headers.GetValues("X-Correlation-Id").Should().HaveCount(1);
+			msg.Headers.GetValues("X-Correlation-Id").First().Should().Be("someCorrelationId");
+			msg.Headers.TryGetValues("Authorization", out IEnumerable<string> tokenValues).Should().BeFalse();
+		}
 
         [Fact]
-        public async void EnhanceClientTest_PassToken_AddsNoAuthHeader()
+        public async void CreateMessageTest_PassToken_AddsNoAuthHeader()
         {
             //Arrange
             var contextReader = new Mock<IContextReader>();
@@ -59,16 +58,14 @@ namespace HttpService.Tests
 
             var httpService = new HttpService(contextReader.Object);
 
-            //Act
-            var client = new HttpClient();
-            await httpService.EnhanceClientAsync(client, true);
+			//Act
+			var msg = await httpService.CreateMessage(HttpMethod.Get, "localhost", true);
 
-            //Assert
-            client.DefaultRequestHeaders.GetValues("X-Correlation-Id").Should().HaveCount(1);
-            client.DefaultRequestHeaders.GetValues("X-Correlation-Id").First().Should().Be("someCorrelationId");
-            IEnumerable<string> tokenValues = null;
-            client.DefaultRequestHeaders.TryGetValues("Authorization", out tokenValues).Should().BeTrue();
-            tokenValues.First().Should().Be("Bearer sometoken");
+			//Assert
+			msg.Headers.GetValues("X-Correlation-Id").Should().HaveCount(1);
+			msg.Headers.GetValues("X-Correlation-Id").First().Should().Be("someCorrelationId");
+			msg.Headers.TryGetValues("Authorization", out IEnumerable<string> tokenValues).Should().BeTrue();
+			tokenValues.First().Should().Be("Bearer sometoken");
         }
 
 


### PR DESCRIPTION
Allow dependency injection of HTTP client to enable extending the request pipeline with additional features, e.g. instrumenting outgoing requests with Amazon X-Ray. Moved adding the X-Correlation-Id header to a custom DelgatingHandler to be dependency injected.

Was able to do this by reusing the HTTP client between requests. (This will hopefully lead to the application using less resources, see [https://aspnetmonsters.com/2016/08/2016-08-27-httpclientwrong/](https://aspnetmonsters.com/2016/08/2016-08-27-httpclientwrong/.))